### PR TITLE
Add the ability to display the support PIN in WHMCS

### DIFF
--- a/v6/includes/hooks/sirportlyHooks.php
+++ b/v6/includes/hooks/sirportlyHooks.php
@@ -84,8 +84,61 @@
         ## Display the "No Recent Tickets Found" message
         $child = $supportTickets->addChild("No Recent Tickets Found. If you need any help, please open a ticket.", array());
       }
+      
+      ## Create support PIN home page panel
+      include(ROOTDIR . "/includes/sirportly/config.php");
+      if ($sirportly_pin_panel) {
+      	$sirportlyContact = findOrCreateSirportlyContact($_SESSION['uid'], $_SESSION['cid']);
+      	$sirportlySupportPIN = FindSupportPIN($sirportlyContact);
+      	$supportPhoneURL = 'tel://' . $sirportly_pin_panel_phone;
+
+      	$homePagePanels->addChild('sirportly_pin', array(
+      	  'label' => 'Support PIN',
+      	  'icon' => 'fa-user',
+      	  'order' => 160,
+      	  'extras' => array(
+      	      'color' => 'blue',
+      	      'btn-link' => $supportPhoneURL,
+      	      'btn-text' => 'Call support',
+      	      'btn-icon' => 'fa-phone',
+      	  ),
+      	  'bodyHtml' => '<h4 align="center">' . $sirportlySupportPIN . '</h4>',
+      	  'footerHtml' => '',
+     	 ));
+     	 
+      }
     });
   }
+
+  ## Add support PIN to secondary sidebar
+  if ((APP::getCurrentFileName()=='supporttickets') or (APP::getCurrentFileName()=='submitticket')) {
+	add_hook('ClientAreaSecondarySidebar', 1, function($secondarySidebar){
+    	include(ROOTDIR . "/includes/sirportly/config.php");
+		if($sirportly_pin_panel) {
+
+			$sirportlyContact = findOrCreateSirportlyContact($_SESSION['uid'], $_SESSION['cid']);
+			$sirportlySupportPIN = FindSupportPIN($sirportlyContact);
+			$supportPhoneURL = 'tel://' . $sirportly_pin_panel_phone;
+			
+			$Support_PIN_Sidebar = $secondarySidebar->addChild('Support PIN', array(
+				'label' => 'Support PIN',
+				'uri' => '#',
+				'icon' => 'fa-user'
+			));
+			
+			$Support_PIN_Sidebar->addChild('Support PIN', array(
+				'uri' => '',
+				'label' => '<h4 align="center">' . $sirportlySupportPIN . '</h4>',
+				'order' => 1
+			));
+			
+			$Support_PIN_Sidebar->setFooterHtml(
+				'<a href="' . $supportPhoneURL . '" class="btn btn-success btn-sm btn-block"><i class="fa fa-phone"></i> Call Support</a>'
+			);			
+		}
+  	});
+  }
+
 
   ## This doesn't deserve to live here
   if (App::getCurrentFilename() == 'submitticket') {

--- a/v6/includes/sirportly/config.example.php
+++ b/v6/includes/sirportly/config.example.php
@@ -31,3 +31,10 @@
   ## The key provided to Sirportly for accessing your data frame, be sure to set this
   ## to a hard to guess value.
   $sirportlyFrameKey = 'LONG-RANDOM-STRING';
+    
+  ## Whether the support PIN home panel should be displayed to clients
+  $sirportly_pin_panel = true;
+  
+  ## The phone number to use for the call support button on the PIN panel
+  ## Numbers only apart from + and -
+  $sirportly_pin_panel_phone = "01234567890";

--- a/v6/includes/sirportly/functions.php
+++ b/v6/includes/sirportly/functions.php
@@ -320,4 +320,11 @@ function rearray_uploaded_files(&$file_post) {
   return $file_ary;
 }
 
+function FindSupportPIN($contactID) {
+	
+	$sirportly_contact = _doSirportlyAPICall('contacts/info', array('contact' => $contactID), true);
+	$sirportly_supportpin = $sirportly_contact['pin'];
+	return $sirportly_supportpin;
+}
+
 ?>


### PR DESCRIPTION
These changes add new hooks to display the Sirportly support PIN in home page panels and side bar widgets. The sidebar widgets display on the ticket list and submit ticket pages. They also feature a click to call tel:// link to call support directly from the browser.

The option to display is defined in a new config file option, and the support number for click to call links is also defined there in a new option.
